### PR TITLE
[Update] 会員編集のバリデーション、注文画面更新時のエラー画面

### DIFF
--- a/app/controllers/public/orders_controller.rb
+++ b/app/controllers/public/orders_controller.rb
@@ -4,6 +4,9 @@ class Public::OrdersController < ApplicationController
   def new
   end
 
+  def error 
+  end
+
   def confirm
     @cart_items = CartItem.where(customer_id: current_customer.id)
     @shipping_cost = 800
@@ -15,32 +18,31 @@ class Public::OrdersController < ApplicationController
     ary = []
     @cart_items.each do |cart_item|
       ary << cart_item.item.with_tax_price*cart_item.amount
-  end
+    end
     @cart_items_price = ary.sum
 
     @billing_amount = @shipping_cost + @cart_items_price
 
     @address_type = params[:order][:address_type]
-  case @address_type
-  when "customer_address"
-    @selected_address = current_customer.postal_code + " " + current_customer.address + " " + current_customer.last_name + current_customer.first_name
-  when "registered_address"
-    unless params[:order][:registered_address_id] == ""
-      selected = Address.find(params[:order][:registered_address_id])
-      @selected_address = selected.postal_code + " " + selected.address + " " + selected.name
-    else
-      flash.now[:notice] = "お届け先を選択してください"
-      render :new
+    case @address_type
+    when "customer_address"
+      @selected_address = current_customer.postal_code + " " + current_customer.address + " " + current_customer.last_name + current_customer.first_name
+    when "registered_address"
+      unless params[:order][:registered_address_id] == ""
+        selected = Address.find(params[:order][:registered_address_id])
+        @selected_address = selected.postal_code + " " + selected.address + " " + selected.name
+      else
+        flash.now[:notice] = "お届け先を選択してください"
+        render :new
+      end
+    when "new_address"
+      unless params[:order][:new_postal_code] == "" && params[:order][:new_address] == "" && params[:order][:new_name] == ""
+        @selected_address = params[:order][:new_postal_code] + " " + params[:order][:new_address] + " " + params[:order][:new_name]
+      else
+        flash.now[:notice] = "お届け先を記入してください"
+        render :new
+      end
     end
-  when "new_address"
-    unless params[:order][:new_postal_code] == "" && params[:order][:new_address] == "" && params[:order][:new_name] == ""
-      @selected_address = params[:order][:new_postal_code] + " " + params[:order][:new_address] + " " + params[:order][:new_name]
-    else
-      flash.now[:notice] = "お届け先を記入してください"
-      render :new
-    end
-  end
-
 
   end
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -12,7 +12,6 @@ class Customer < ApplicationRecord
   validates :last_name_kana,    presence: true, length: {maximum: 20}, format: { with: /\A[\p{katakana}\u{30fc}]+\z/ }
   validates :first_name,        presence: true, length: {maximum: 20}
   validates :first_name_kana,   presence: true, length: {maximum: 20}, format: { with: /\A[\p{katakana}\u{30fc}]+\z/ }
-
   validates :email,             presence: true, uniqueness: true
   validates :postal_code,       presence: true, length: {is: 7},  numericality: {only_integer: true}
   validates :address,           presence: true, length: {maximum: 50}

--- a/app/views/public/customers/edit.html.erb
+++ b/app/views/public/customers/edit.html.erb
@@ -1,10 +1,10 @@
 <div class="container">
   <div class="row">
     <div class="col">
-      <h4 class="my-5">会員情報編集</h4>
-      
+      <h3 class="my-5">会員情報編集</h3>
+
       <%= form_with model: @customer, url: customers_path, method: :patch do |f| %>
-      
+      <%= render 'layouts/error', obj: @customer %>
         <table class="table table-borderless">
           <tr>
             <td>氏名</td>

--- a/app/views/public/customers/show.html.erb
+++ b/app/views/public/customers/show.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
   <div class="row">
     <div class="col">
-      <h4 class="my-5">マイページ</h4>
+      <h3 class="my-5">マイページ</h3>
         <div class="d-flex align-items-center">
-          <h3><b>登録情報</b></h3>
+          <h4><b>登録情報</b></h4>
           <%= link_to "編集する", customers_information_edit_path, class:"btn btn-success ml-3" %>
         </div>
           <table class="table table-bordered">
@@ -37,15 +37,15 @@
               <td><%= @customer.email %></td>
             </tr>
           </table>
-            <div class="d-flex align-items-center">
-              <h3><b>配送先</b></h3>
-              &emsp;&emsp;<%= link_to "一覧を見る", addresses_path, class: "btn btn-primary ml-3" %>
-            </div>
-            <div class="d-flex align-items-center">
-              <h3><b>注文履歴</b></h3>
-              &thinsp;&thinsp;<%= link_to "一覧を見る", orders_path, class: "btn btn-primary ml-3" %>
-           </div>
-
+          <div class="d-flex align-items-center">
+            <h4><b>配送先</b></h4>
+            &emsp;&emsp;<%= link_to "一覧を見る", addresses_path, class: "btn btn-primary ml-3" %>
+          </div>
+          <br>
+          <div class="d-flex align-items-center">
+            <h4><b>注文履歴</b></h4>
+            &thinsp;&thinsp;<%= link_to "一覧を見る", orders_path, class: "btn btn-primary ml-3" %>
+         </div>
     </div>
   </div>
 </div>

--- a/app/views/public/orders/confirm.html.erb
+++ b/app/views/public/orders/confirm.html.erb
@@ -37,15 +37,16 @@
         </tr>
       </table>
 
-      <h4>支払い方法</h4>
+      <h4>[支払い方法]</h4>
 
       <% if @selected_payment_method == "credit_card" %>
         クレジットカード
       <% else %>
         銀行振込
       <% end %>
-
-      <h4>お届け先</h4>
+      <br>
+      <br>
+      <h4>[お届け先]</h4>
       <%= @selected_address %>
 
       <%= form_with url: orders_path, method: :post do %>
@@ -60,6 +61,7 @@
           <%= hidden_field_tag 'order[new_address]', params[:order][:new_address] %>
           <%= hidden_field_tag 'order[new_name]', params[:order][:new_name] %>
         <% end %>
+        <br>
         <%= submit_tag "注文を確定する", class: "btn btn-success" %>
       <% end %>
     </div>

--- a/app/views/public/orders/error.html.erb
+++ b/app/views/public/orders/error.html.erb
@@ -1,0 +1,9 @@
+<div class="container p-3">
+  <div class="row">
+
+    <div class="col-md-12 text-center mt-5">
+      <h4 class="mb-3">エラーが発生しました！</h4>
+      <%= link_to "情報入力画面へ戻る", new_order_path, class: "btn btn-success mx-auto" %>
+    </div>
+  </div>
+</div>

--- a/app/views/public/orders/new.html.erb
+++ b/app/views/public/orders/new.html.erb
@@ -2,9 +2,9 @@
   <div class="row">
 
     <div class="col-12">
-      <h3 class="mb-3 border-bottom border-dark pb-3 text-secondary">注文情報入力</h3>
+      <h3 class="mb-3 border-bottom border-dark pb-3">注文情報入力</h3>
     </div>
-    <%= form_with model: Order.new, url: confirm_orders_path, local:true do |f|  %>
+    <%= form_with model: Order.new, url: orders_confirm_path, local:true do |f|  %>
     <div class="col-12">
       <div class="mb-3">
       <h5>お支払い方法</h5>
@@ -37,7 +37,8 @@
       <%= f.label :address_type, "新しいお届け先" %>
 
       <div class="col-md-3">
-        郵便番号(ハイフンなし)
+        郵便番号<br>
+        (ハイフンなし)
       </div>
       <div class="col-md-3 ml-1">
         <%= f.text_field :new_postal_code, placeholder: "0000000", class: "mt-1" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,6 @@ module NaganoCake
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.action_view.field_error_proc = Proc.new { |html_tag, instance| html_tag }
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,12 +18,10 @@ Rails.application.routes.draw do
     patch "/customers/withdraw" => "customers#withdraw"
     delete "/cart_items/destroy_all" => "cart_items#destroy_all"
     resources :cart_items, only: [:index, :create, :update, :destroy]
-    resources :orders, only: [:new, :create, :index, :show] do
-      collection do
-        post 'confirm'
-        get 'complete'
-      end
-    end
+    post "/orders/confirm" => "orders#confirm"
+    get "/orders/confirm" => "orders#error"
+    get "/orders/complete" => "orders#complete"
+    resources :orders, only: [:new, :create, :index, :show]
     resources :addresses, only: [:index, :edit, :create, :update, :destroy]
   end
 


### PR DESCRIPTION
会員情報編集のバリデーションのエラー分追加と、エラー時にレイアウトが崩れないように設定
注文機能の確認画面でリロードした時にエラー画面が出ていたものを、
会員向けのエラー画面が表示されるようにエラー画面作成しました。
その他レイアウトの見出し文字の大きさ調整しました。